### PR TITLE
Rancher frontend host rule template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,16 +1,30 @@
 <!--
-PLEASE READ THIS MESSAGE.
+DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 
-=== DO *NOT* FILE ISSUES FOR GENERAL SUPPORT QUESTIONS. ===
-
-The issue tracker is for reporting bugs and feature requests only. For end-user related support questions, refer to one of the following:
+The issue tracker is for reporting bugs and feature requests only.
+For end-user related support questions, refer to one of the following:
 
 - Stack Overflow (using the "traefik" tag): https://stackoverflow.com/questions/tagged/traefik
 - the Traefik community Slack channel: https://traefik.herokuapp.com
 
+-->
+
+### Do you want to request a *feature* or report a *bug*?
+
+(If you intend to ask a support question: **DO NOT FILE AN ISSUE**.
+Use [Stack Overflow](https://stackoverflow.com/questions/tagged/traefik)
+or [Slack](https://traefik.herokuapp.com) instead.)
+
+
+
+### What did you do?
+
+<!--
+
 HOW TO WRITE A GOOD ISSUE?
 
-- if it's possible use the command `traefik bug`. See https://www.youtube.com/watch?v=Lyz62L8m93I. 
+- Respect the issue template as more as possible.
+- If it's possible use the command `traefik bug`. See https://www.youtube.com/watch?v=Lyz62L8m93I. 
 - The title must be short and descriptive.
 - Explain the conditions which led you to write this issue: the context.
 - The context should lead to something, an idea or a problem that you’re facing.
@@ -18,16 +32,6 @@ HOW TO WRITE A GOOD ISSUE?
 - Format your messages to help the reader focus on what matters and understand the structure of your message, use Markdown syntax https://help.github.com/articles/github-flavored-markdown
 
 -->
-
-### Do you want to request a *feature* or report a *bug*?
-
-(If you intend to ask a support question: **DO NOT FILE AN ISSUE**. Use [Stack Overflow](https://stackoverflow.com/questions/tagged/traefik) or [Slack](https://traefik.herokuapp.com) instead.)
-
-
-
-### What did you do?
-
-
 
 ### What did you expect to see?
 

--- a/cmd/traefik/bug.go
+++ b/cmd/traefik/bug.go
@@ -17,18 +17,32 @@ import (
 var (
 	bugtracker  = "https://github.com/containous/traefik/issues/new"
 	bugTemplate = `<!--
-PLEASE READ THIS MESSAGE.
+DO NOT FILE ISSUES FOR GENERAL SUPPORT QUESTIONS.
 
-Please keep in mind that the GitHub issue tracker is not intended as a general support forum, but for reporting bugs and feature requests.
+The issue tracker is for reporting bugs and feature requests only.
+For end-user related support questions, refer to one of the following:
 
-For other type of questions, consider using one of:
-
+- Stack Overflow (using the "traefik" tag): https://stackoverflow.com/questions/tagged/traefik
 - the Traefik community Slack channel: https://traefik.herokuapp.com
-- StackOverflow: https://stackoverflow.com/questions/tagged/traefik
+
+-->
+
+### Do you want to request a *feature* or report a *bug*?
+
+(If you intend to ask a support question: **DO NOT FILE AN ISSUE**.
+Use [Stack Overflow](https://stackoverflow.com/questions/tagged/traefik)
+or [Slack](https://traefik.herokuapp.com) instead.)
+
+
+
+### What did you do?
+
+<!--
 
 HOW TO WRITE A GOOD ISSUE?
 
-- if it's possible use the command` + "`" + `traefik bug` + "`" + `. See https://www.youtube.com/watch?v=Lyz62L8m93I.
+- Respect the issue template as more as possible.
+- If it's possible use the command ` + "`" + "traefik bug" + "`" + `. See https://www.youtube.com/watch?v=Lyz62L8m93I.
 - The title must be short and descriptive.
 - Explain the conditions which led you to write this issue: the context.
 - The context should lead to something, an idea or a problem that you’re facing.
@@ -36,12 +50,6 @@ HOW TO WRITE A GOOD ISSUE?
 - Format your messages to help the reader focus on what matters and understand the structure of your message, use Markdown syntax https://help.github.com/articles/github-flavored-markdown
 
 -->
-
-### Do you want to request a *feature* or report a *bug*?
-
-
-### What did you do?
-
 
 
 ### What did you expect to see?

--- a/docs/toml.md
+++ b/docs/toml.md
@@ -1670,6 +1670,11 @@ EnableServiceHealthFilter = false
 # Required
 # SecretKey = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
+# FrontendHostRuleTemplate to use when creating the frontend host rule
+#
+# Optional
+# FrontendHostRuleTemplate = "{{.Service}}-{{.Environment}}-{{.Project}}.{{.Domain}}"
+
 ```
 
 As traefik needs access to the rancher API, you need to set the `endpoint`, `accesskey` and `secretkey` parameters. 

--- a/provider/rancher/rancher_test.go
+++ b/provider/rancher/rancher_test.go
@@ -287,6 +287,48 @@ func TestRancherGetFrontendRule(t *testing.T) {
 	}
 }
 
+func TestRancherGetFrontendRuleWithTemplate(t *testing.T) {
+	services := []struct {
+		provider *Provider
+		service  rancherData
+		expected string
+	}{
+		{
+			provider: &Provider{
+				Domain: "rancher.localhost",
+				FrontendHostRuleTemplate: "{{.Environment}}-{{.Service}}-{{.Project}}.{{.Domain}}",
+			},
+			service: rancherData{
+				Name: "foo/bar",
+				Environment: "foo",
+				Service: "bar",
+				Project: "env",
+			},
+			expected: "Host:foo-bar-env.rancher.localhost",
+		},
+		{
+			provider: &Provider{
+				Domain: "rancher.localhost",
+				FrontendHostRuleTemplate: "{{.Service}}-{{.Environment}}-{{.Project}}.{{.Domain}}",
+			},
+			service: rancherData{
+				Name: "foo/bar",
+				Environment: "foo",
+				Service: "bar",
+				Project: "env",
+			},
+			expected: "Host:bar-foo-env.rancher.localhost",
+		},
+	}
+
+	for _, e := range services {
+		actual := e.provider.getFrontendRule(e.service)
+		if actual != e.expected {
+			t.Fatalf("expected %q, got %q", e.expected, actual)
+		}
+	}
+}
+
 func TestRancherGetBackend(t *testing.T) {
 	provider := &Provider{
 		Domain: "rancher.localhost",


### PR DESCRIPTION
### Description

I love traefik and rancher.

At work we are using them for our development environment but we have to use this project https://github.com/digitalLumberjack/rancher-traefik because of our wildcard certificate.

I would like to use the rancher provider but I need a simple way to build my traefik rules.

In this PR you can configure the default frontend host rule via the `FrontendHostRuleTemplate` configuration.

---

@digitalLumberjack, my open source mentor, can you review this PR please.

some points of attention : 
- `FrontendHostRuleTemplate` maybe just `Template`? or something else?
- Syntax of the template, Go template? or something else?
- Vocabulary of the template, currently it sticks to the v1 rancher api.


